### PR TITLE
Implement scan pause/resume with progress save

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,193 @@
+let timer = null;
+let currentIndex = 0;
+let friendLinks = [];
+let tabId = null;
+let allProfiles = [];
+let isPaused = false;
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "start") {
+    tabId = message.tabId;
+    chrome.storage.local.get(['delay'], (result) => {
+      startProcess(tabId, parseInt(result.delay) || 3000);
+    });
+  } else if (message.action === "stop") {
+    stopProcess();
+  } else if (message.action === "pause") {
+    pauseProcess();
+  } else if (message.action === "resume") {
+    tabId = message.tabId;
+    chrome.storage.local.get(['delay'], (result) => {
+      resumeProcess(tabId, parseInt(result.delay) || 3000);
+    });
+  } else if (message.action === "resetData") {
+    allProfiles = [];
+    chrome.storage.local.set({ allProfiles });
+  } else if (message.action === "log") {
+    chrome.runtime.sendMessage(message);
+  }
+});
+
+function startProcess(tabId, delay) {
+  stopProcess();
+  isPaused = false;
+  logMessage("Démarrage du scan...");
+  
+  chrome.scripting.executeScript({
+    target: { tabId },
+    func: () => {
+      const links = [];
+      document.querySelectorAll('.selectable_overlay').forEach(el => {
+        const href = el.getAttribute('href');
+        if (href && !href.includes('/id/') && !href.includes('/friends')) {
+          links.push(href.startsWith('https://') ? href : `https://steamcommunity.com${href}`);
+        }
+      });
+      return links;
+    }
+  }, (results) => {
+    if (results?.[0]?.result) {
+      friendLinks = results[0].result;
+      currentIndex = 0;
+      allProfiles = [];
+      chrome.storage.local.set({ friendLinks, currentIndex, allProfiles, scanState: 'running' });
+      
+      if (friendLinks.length > 0) {
+        logMessage(`${friendLinks.length} profils trouvés`);
+        chrome.runtime.sendMessage({ 
+          action: "progress", 
+          current: 0, 
+          total: friendLinks.length 
+        });
+        if (!isPaused) processNextFriend(tabId, delay);
+      } else {
+        logMessage("Aucun profil trouvé");
+      }
+    }
+  });
+}
+
+function stopProcess() {
+  if (timer) clearTimeout(timer);
+  timer = null;
+  isPaused = false;
+  currentIndex = 0;
+  friendLinks = [];
+  chrome.storage.local.set({ scanState: 'stopped', friendLinks: [], currentIndex: 0 });
+}
+
+function pauseProcess() {
+  if (timer) clearTimeout(timer);
+  timer = null;
+  isPaused = true;
+  chrome.storage.local.set({ friendLinks, currentIndex, allProfiles, scanState: 'paused' });
+  logMessage('Scan mis en pause');
+}
+
+function resumeProcess(tabId, delay) {
+  if (!friendLinks.length) {
+    chrome.storage.local.get(['friendLinks', 'currentIndex', 'allProfiles'], (data) => {
+      friendLinks = data.friendLinks || [];
+      currentIndex = data.currentIndex || 0;
+      allProfiles = data.allProfiles || [];
+      if (!friendLinks.length) {
+        logMessage('Aucune progression \u00e0 reprendre');
+        return;
+      }
+      logMessage('Reprise du scan...');
+      chrome.storage.local.set({ scanState: 'running' });
+      if (!isPaused) processNextFriend(tabId, delay);
+    });
+  } else {
+    logMessage('Reprise du scan...');
+    chrome.storage.local.set({ scanState: 'running' });
+    if (!isPaused) processNextFriend(tabId, delay);
+  }
+}
+
+function processNextFriend(tabId, delay) {
+  if (currentIndex >= friendLinks.length || !tabId) {
+    logMessage("Scan terminé !");
+    chrome.runtime.sendMessage({ 
+      action: "progress", 
+      current: friendLinks.length, 
+      total: friendLinks.length 
+    });
+    stopProcess();
+    return;
+  }
+  
+  const baseUrl = friendLinks[currentIndex].split('/inventory')[0];
+  const inventoryUrl = `${baseUrl}/inventory`;
+  
+  logMessage(`Scan du profil ${currentIndex + 1}/${friendLinks.length}: ${baseUrl}`);
+  
+  chrome.tabs.update(tabId, { url: inventoryUrl }, () => {
+    timer = setTimeout(() => {
+      // Détecter la valeur et les caisses
+      chrome.scripting.executeScript({
+        target: { tabId },
+        func: () => {
+          // Détection de la valeur
+          let totalValue = 0;
+          const priceContainer = document.querySelector('.platform_container.steam .price');
+          if (priceContainer) {
+            const priceText = priceContainer.textContent.trim();
+            const match = priceText.match(/[\d,]+\.?\d*/);
+            if (match) {
+              totalValue = parseFloat(match[0].replace(',', ''));
+            }
+          }
+          
+          // Détection des caisses
+          let caseCount = 0;
+          const items = document.querySelectorAll('.item.app730');
+          items.forEach(item => {
+            const itemName = (item.getAttribute('data-market-hashname') || '').toLowerCase();
+            if (itemName.includes('case') && !itemName.includes('key')) {
+              caseCount++;
+            }
+          });
+          
+          return {
+            value: totalValue,
+            cases: caseCount
+          };
+        }
+      }, (results) => {
+        const data = results[0]?.result || { value: 0, cases: 0 };
+        
+        // Stocker le profil
+        allProfiles.push({
+          url: baseUrl,
+          value: data.value,
+          cases: data.cases
+        });
+        chrome.storage.local.set({ allProfiles, currentIndex, friendLinks });
+        
+        // Mettre à jour la progression
+        chrome.runtime.sendMessage({ 
+          action: "progress", 
+          current: currentIndex + 1, 
+          total: friendLinks.length 
+        });
+        
+        // Log des résultats
+        logMessage(`→ Valeur: ${data.value}€ | Caisses: ${data.cases}`);
+        
+        // Passer au profil suivant
+        currentIndex++;
+        chrome.storage.local.set({ friendLinks, currentIndex, allProfiles });
+        if (!isPaused) processNextFriend(tabId, delay);
+      });
+    }, delay);
+  });
+}
+
+function logMessage(message) {
+  chrome.runtime.sendMessage({ 
+    action: "log", 
+    text: message,
+    timestamp: new Date().toLocaleTimeString()
+  });
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Steam Inventory Scanner",
+  "version": "1.0",
+  "description": "Analyse les inventaires CS2 de vos amis Steam",
+  "permissions": ["activeTab", "storage", "scripting", "downloads"],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Steam Inventory Scanner</title>
+  <style>
+    body {
+      width: 450px;
+      height: 500px;
+      padding: 15px;
+      font-family: 'Courier New', monospace;
+      background-color: #000;
+      color: #0f0;
+      margin: 0;
+      position: relative;
+      overflow: hidden;
+    }
+    
+    /* Effet Matrix */
+    body::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(rgba(0, 0, 0, 0.1) 50%, rgba(0, 15, 0, 0.25) 50%),
+                  linear-gradient(90deg, rgba(0, 15, 0, 0.25), rgba(0, 0, 0, 0.1));
+      background-size: 100% 4px, 4px 100%;
+      pointer-events: none;
+      z-index: -1;
+    }
+    
+    .control-group {
+      margin-bottom: 15px;
+    }
+    
+    label {
+      display: block;
+      margin-bottom: 5px;
+      font-weight: bold;
+      color: #0f0;
+      text-shadow: 0 0 5px #0f0;
+    }
+    
+    input[type="range"] {
+      width: 100%;
+      background: #003300;
+      height: 5px;
+      outline: none;
+    }
+    
+    input[type="range"]::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: 15px;
+      height: 15px;
+      background: #0f0;
+      border-radius: 50%;
+      cursor: pointer;
+      box-shadow: 0 0 5px #0f0;
+    }
+    
+    .delay-value {
+      text-align: center;
+      margin: 5px 0;
+      font-size: 14px;
+      color: #0f0;
+      text-shadow: 0 0 3px #0f0;
+    }
+    
+    #toggleButton {
+      width: 100%;
+      padding: 10px;
+      background-color: #002200;
+      color: #0f0;
+      border: 1px solid #0f0;
+      border-radius: 0;
+      cursor: pointer;
+      font-size: 14px;
+      margin-bottom: 15px;
+      font-family: 'Courier New', monospace;
+      text-shadow: 0 0 3px #0f0;
+      box-shadow: 0 0 5px #0f0;
+      transition: all 0.3s;
+    }
+    
+    #toggleButton:hover {
+      background-color: #004400;
+      box-shadow: 0 0 10px #0f0;
+    }
+    
+    .progress-container {
+      margin: 15px 0;
+      background: #001100;
+      border: 1px solid #0a0;
+      border-radius: 0;
+      overflow: hidden;
+      box-shadow: 0 0 5px #0f0;
+    }
+    
+    #progressBar {
+      height: 20px;
+      background: linear-gradient(90deg, #002200, #00aa00);
+      width: 0%;
+      transition: width 0.3s;
+    }
+    
+    #progressText {
+      text-align: center;
+      font-size: 12px;
+      padding: 3px;
+      color: #0f0;
+      text-shadow: 0 0 3px #0f0;
+      background: rgba(0, 20, 0, 0.5);
+    }
+    
+    .console-container {
+      margin: 15px 0;
+      background: #000;
+      border: 1px solid #0a0;
+      height: 180px;
+      overflow-y: auto;
+      padding: 10px;
+      box-shadow: inset 0 0 10px #0a0;
+      font-size: 13px;
+      line-height: 1.4;
+    }
+    
+    #consoleOutput {
+      height: 100%;
+    }
+    
+    .log-entry {
+      margin-bottom: 5px;
+      padding: 3px;
+      transition: all 0.5s;
+    }
+    
+    .timestamp {
+      color: #0a0;
+      margin-right: 5px;
+    }
+    
+    .section {
+      display: flex;
+      justify-content: space-between;
+      margin-top: 15px;
+    }
+    
+    .export-button, #resetButton {
+      width: 48%;
+      padding: 8px;
+      background-color: #002200;
+      color: #0f0;
+      border: 1px solid #0f0;
+      border-radius: 0;
+      cursor: pointer;
+      font-size: 12px;
+      font-family: 'Courier New', monospace;
+      text-shadow: 0 0 2px #0f0;
+      transition: all 0.3s;
+    }
+    
+    .export-button:hover, #resetButton:hover {
+      background-color: #004400;
+      box-shadow: 0 0 5px #0f0;
+    }
+    
+    .count-display {
+      text-align: center;
+      margin: 10px 0;
+      padding: 8px;
+      background: #001100;
+      border: 1px solid #0a0;
+      color: #0f0;
+      text-shadow: 0 0 3px #0f0;
+    }
+    
+    .credits {
+      position: absolute;
+      bottom: 5px;
+      right: 10px;
+      font-size: 10px;
+      color: #0a0;
+      font-style: italic;
+    }
+    
+    /* Barre de défilement style Matrix */
+    .console-container::-webkit-scrollbar {
+      width: 8px;
+    }
+    
+    .console-container::-webkit-scrollbar-track {
+      background: #001100;
+    }
+    
+    .console-container::-webkit-scrollbar-thumb {
+      background: #00aa00;
+      border-radius: 0;
+    }
+    
+    .console-container::-webkit-scrollbar-thumb:hover {
+      background: #0f0;
+    }
+  </style>
+</head>
+<body>
+  <div class="control-group">
+    <label for="delay">DÉLAI ENTRE LES PROFILS (MS):</label>
+    <input type="range" id="delay" min="2000" max="10000" value="3000" step="500">
+    <div class="delay-value" id="delayValue">3000 ms</div>
+  </div>
+  
+  <button id="toggleButton">DÉMARRER LE SCAN</button>
+  
+  <div class="progress-container">
+    <div id="progressBar"></div>
+    <div id="progressText">EN ATTENTE...</div>
+  </div>
+  
+  <div class="count-display" id="allCount">0 PROFILS ANALYSÉS</div>
+  
+  <div class="console-container">
+    <div id="consoleOutput"></div>
+  </div>
+  
+  <div class="section">
+    <button class="export-button" id="exportButton">EXPORTER CSV</button>
+    <button id="resetButton">RÉINITIALISER</button>
+  </div>
+  
+  <div class="credits">by syokos</div>
+  
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,163 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleButton = document.getElementById('toggleButton');
+  const delaySlider = document.getElementById('delay');
+  const delayValue = document.getElementById('delayValue');
+  const exportButton = document.getElementById('exportButton');
+  const resetButton = document.getElementById('resetButton');
+  const progressBar = document.getElementById('progressBar');
+  const progressText = document.getElementById('progressText');
+  const allCount = document.getElementById('allCount');
+  const consoleOutput = document.getElementById('consoleOutput');
+  
+  // Initialiser le délai et l'état
+  chrome.storage.local.get(['delay', 'scanState'], (data) => {
+    if (data.delay) {
+      delaySlider.value = data.delay;
+    }
+    delayValue.textContent = `${delaySlider.value} ms`;
+    setButtonState(data.scanState || 'stopped');
+  });
+  delaySlider.addEventListener('input', () => {
+    delayValue.textContent = `${delaySlider.value} ms`;
+  });
+  
+  // Gérer le bouton de démarrage/pause/reprise
+  toggleButton.addEventListener('click', async () => {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+    chrome.storage.local.get('scanState', (data) => {
+      const state = data.scanState || 'stopped';
+
+      if (state === 'stopped') {
+        if (!tab?.url?.includes('steamcommunity.com')) {
+          alert("Veuillez d'abord ouvrir votre liste d'amis Steam.\nExemple: https://steamcommunity.com/id/votrepseudo/friends/");
+          return;
+        }
+        clearConsole();
+        chrome.storage.local.set({ delay: delaySlider.value, scanState: 'running' });
+        chrome.runtime.sendMessage({ action: 'start', tabId: tab.id });
+        setButtonState('running');
+      } else if (state === 'running') {
+        chrome.storage.local.set({ scanState: 'paused' });
+        chrome.runtime.sendMessage({ action: 'pause' });
+        setButtonState('paused');
+      } else if (state === 'paused') {
+        chrome.storage.local.set({ scanState: 'running' });
+        chrome.runtime.sendMessage({ action: 'resume', tabId: tab.id });
+        setButtonState('running');
+      }
+    });
+  });
+
+  function setButtonState(state) {
+    if (state === 'running') {
+      toggleButton.textContent = 'Pause';
+    } else if (state === 'paused') {
+      toggleButton.textContent = 'Reprendre';
+    } else {
+      toggleButton.textContent = 'Démarrer le scan';
+    }
+  }
+  
+  // Mettre à jour le compteur de profils
+  function updateCount() {
+    chrome.storage.local.get('allProfiles', (data) => {
+      const all = data.allProfiles || [];
+      allCount.textContent = `${all.length} profils analysés`;
+    });
+  }
+  
+  // Écouter les changements de stockage
+  chrome.storage.onChanged.addListener((changes) => {
+    if (changes.allProfiles) {
+      updateCount();
+    }
+  });
+  
+  // Écouter les mises à jour de progression
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.action === "progress") {
+      const percent = Math.round((message.current / message.total) * 100);
+      progressBar.style.width = `${percent}%`;
+      progressText.textContent = `${message.current}/${message.total} (${percent}%)`;
+      
+      if (message.current === message.total) {
+        progressText.textContent = "Terminé !";
+        setButtonState('stopped');
+      }
+    }
+    else if (message.action === "log") {
+      addLog(message.text, message.timestamp);
+    }
+  });
+  
+  // Bouton d'export
+  exportButton.addEventListener('click', () => {
+    chrome.storage.local.get('allProfiles', (data) => {
+      const profiles = data.allProfiles || [];
+      if (profiles.length === 0) {
+        alert("Aucune donnée à exporter !");
+        return;
+      }
+      
+      let csv = 'Profil,Valeur,Caisses\n';
+      profiles.forEach(profile => {
+        csv += `"${profile.url}",${profile.value},${profile.cases}\n`;
+      });
+      
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', `steam_inventories_${new Date().toISOString().slice(0,10)}.csv`);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      
+      addLog("Données exportées en CSV");
+    });
+  });
+  
+  // Bouton de réinitialisation
+  resetButton.addEventListener('click', () => {
+    if (confirm("Voulez-vous vraiment réinitialiser toutes les données ?")) {
+      chrome.runtime.sendMessage({ action: "resetData" });
+      allProfiles = [];
+      updateCount();
+      progressBar.style.width = `0%`;
+      progressText.textContent = "En attente...";
+      addLog("Données réinitialisées");
+    }
+  });
+  
+  // Ajouter un message à la console
+  function addLog(message, timestamp = new Date().toLocaleTimeString()) {
+    const logEntry = document.createElement('div');
+    logEntry.className = 'log-entry';
+    logEntry.innerHTML = `<span class="timestamp">[${timestamp}]</span> ${message}`;
+    consoleOutput.appendChild(logEntry);
+    
+    // Effet Matrix
+    logEntry.style.opacity = '0';
+    setTimeout(() => {
+      logEntry.style.opacity = '1';
+      logEntry.style.textShadow = '0 0 5px #00ff00';
+    }, 10);
+    
+    setTimeout(() => {
+      logEntry.style.textShadow = 'none';
+    }, 500);
+    
+    // Défilement automatique
+    consoleOutput.scrollTop = consoleOutput.scrollHeight;
+  }
+  
+  // Effacer la console
+  function clearConsole() {
+    consoleOutput.innerHTML = '';
+  }
+  
+  // Initialiser le compteur
+  updateCount();
+  addLog("Prêt à scanner");
+});


### PR DESCRIPTION
## Summary
- add Chrome extension source files
- implement pause and resume in `background.js`
- keep scan progress in `chrome.storage`
- update popup script to manage start/pause/resume states

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685169bbdfa48328b3e65b1d202b1e88