### PR TITLE
Fix resume scanning

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -85,6 +85,7 @@ function pauseProcess() {
 }
 
 function resumeProcess(tabId, delay) {
+  isPaused = false;
   if (!friendLinks.length) {
     chrome.storage.local.get(['friendLinks', 'currentIndex', 'allProfiles'], (data) => {
       friendLinks = data.friendLinks || [];


### PR DESCRIPTION
## Summary
- fix pause/resume in background script by resetting `isPaused`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68516c86b78083288d0569b6b9aa34b0