### PR TITLE
Add pause/resume for scanning

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -84,8 +84,30 @@
       box-shadow: 0 0 5px #0f0;
       transition: all 0.3s;
     }
-    
+
+    #resumeButton {
+      width: 100%;
+      padding: 10px;
+      background-color: #002200;
+      color: #0f0;
+      border: 1px solid #0f0;
+      border-radius: 0;
+      cursor: pointer;
+      font-size: 14px;
+      margin-bottom: 15px;
+      font-family: 'Courier New', monospace;
+      text-shadow: 0 0 3px #0f0;
+      box-shadow: 0 0 5px #0f0;
+      transition: all 0.3s;
+      display: none;
+    }
+
     #toggleButton:hover {
+      background-color: #004400;
+      box-shadow: 0 0 10px #0f0;
+    }
+
+    #resumeButton:hover {
       background-color: #004400;
       box-shadow: 0 0 10px #0f0;
     }
@@ -213,6 +235,7 @@
   </div>
   
   <button id="toggleButton">Démarrer</button>
+  <button id="resumeButton">Reprendre</button>
   
   <div class="progress-container">
     <div id="progressBar"></div>


### PR DESCRIPTION
## Summary
- add resume button and styling
- handle pause/resume logic in popup.js
- store progress in background.js and add pause/resume functions

## Testing
- `node --check background.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68517830ed7483288380b82d27949217